### PR TITLE
Fix blog text & fix responsive image

### DIFF
--- a/resources/views/components/blog.blade.php
+++ b/resources/views/components/blog.blade.php
@@ -3,7 +3,7 @@
     @if ($blog->overview_image)
         @responsive($blog->overview_image, ['class' => 'rounded-lg object-cover ' . $imageClass, 'loading' => 'lazy'])
     @endif
-    <div class="flex flex-col self-center flex-1">
+    <div class="flex flex-col flex-1">
         @if ($blog->blog_category->title)
             <span class="text-sm text-secondary-100">{{ $blog->blog_category->title }} - {{ $blog->date->format('Y-m-d') }}</span>
         @endif

--- a/resources/views/page-builder/blog_overview.blade.php
+++ b/resources/views/page-builder/blog_overview.blade.php
@@ -5,7 +5,11 @@
         <div class="flex gap-8 max-lg:flex-col">
             @foreach ($blogs->slice(0, 1) as $blog)
                 <a href="{{ $blog?->url() ?? '' }}" class="flex lg:w-3/5">
-                    <x-blog :$blog class="prose-headings:text-3xl" />
+                    <x-blog
+                        :$blog
+                        image-class="flex-1"
+                        class="w-full prose-headings:text-3xl *:flex *:flex-1"
+                    />
                 </a>
             @endforeach
             @if (count($blogs) > 1)


### PR DESCRIPTION
Remove `self-center` so text will align left: 
<img width="1720" alt="Scherm­afbeelding 2025-07-02 om 11 15 03" src="https://github.com/user-attachments/assets/911e0d50-bf7c-41d3-8d93-19d77f4feb37" />

Make image stretch responsive:
_Old vs New_
<img width="992" alt="Scherm­afbeelding 2025-07-02 om 11 16 09" src="https://github.com/user-attachments/assets/8ad73b09-84b5-4577-9d08-8d999ea3b266" />
<img width="984" alt="Scherm­afbeelding 2025-07-02 om 11 15 53" src="https://github.com/user-attachments/assets/99b191bb-5859-4b26-9ec7-25ec833d5fe9" />

